### PR TITLE
Refactor options/config file parsing

### DIFF
--- a/cmd/swo/main.go
+++ b/cmd/swo/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"github.com/solarwinds/swo-cli/config"
 	"log"
 	"os"
 
@@ -16,12 +17,25 @@ func main() {
 		Usage:   "SolarWinds Observability Command-Line Interface",
 		Version: version,
 		Flags: []cli.Flag{
-			&cli.StringFlag{Name: "api-url", Usage: "URL of the SWO API", Value: logs.DefaultAPIURL},
-			&cli.StringFlag{Name: "api-token", Usage: "API token"},
-			&cli.StringFlag{Name: "config", Aliases: []string{"c"}, Usage: "path to config", Value: logs.DefaultConfigFile},
+			&cli.StringFlag{Name: config.APIURLContextKey, Usage: "URL of the SWO API", Value: config.DefaultAPIURL},
+			&cli.StringFlag{Name: config.TokenContextKey, Usage: "API token"},
+			&cli.StringFlag{Name: "config", Aliases: []string{"c"}, Usage: "path to config", Value: config.DefaultConfigFile},
 		},
 		Commands: []*cli.Command{
 			logs.NewLogsCommand(),
+		},
+		Before: func(cCtx *cli.Context) error {
+			cfg, err := config.Init(cCtx.String("config"), cCtx.String("api-url"), cCtx.String("api-token"))
+			if err != nil {
+				return err
+			}
+			if err = cCtx.Set(config.APIURLContextKey, cfg.APIURL); err != nil {
+				return err
+			}
+			if err = cCtx.Set(config.TokenContextKey, cfg.Token); err != nil {
+				return err
+			}
+			return nil
 		},
 	}
 

--- a/config/config.go
+++ b/config/config.go
@@ -1,0 +1,80 @@
+package config
+
+import (
+	"errors"
+	"fmt"
+	"gopkg.in/yaml.v3"
+	"os"
+	"os/user"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	DefaultConfigFile = "~/.swo-cli.yml"
+	DefaultAPIURL     = "https://api.na-01.cloud.solarwinds.com"
+	APIURLContextKey  = "api-url"
+	TokenContextKey   = "token"
+)
+
+var (
+	errMissingToken  = errors.New("failed to find token")
+	errMissingAPIURL = errors.New("failed to find API URL")
+)
+
+type Config struct {
+	APIURL string `yaml:"api-url"`
+	Token  string `yaml:"token"`
+}
+
+/*
+ * Precedence: CLI flags, environment, config file
+ */
+func Init(configPath string, apiURL string, apiToken string) (*Config, error) {
+	config := &Config{
+		APIURL: apiURL,
+		Token:  apiToken,
+	}
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		return nil, err
+	}
+
+	localConfig := filepath.Join(cwd, ".swo-cli.yaml")
+	if _, err := os.Stat(localConfig); err == nil {
+		configPath = localConfig
+	} else if strings.HasPrefix(configPath, "~/") {
+		usr, err := user.Current()
+		if err != nil {
+			return nil, fmt.Errorf("error while resolving current user to read configuration file: %w", err)
+		}
+
+		configPath = filepath.Join(usr.HomeDir, configPath[2:])
+	}
+
+	if content, err := os.ReadFile(configPath); err == nil {
+		err = yaml.Unmarshal(content, config)
+		if err != nil {
+			return nil, fmt.Errorf("error while unmarshaling %s config file: %w", configPath, err)
+		}
+	}
+
+	if token := os.Getenv("SWO_API_TOKEN"); token != "" {
+		config.Token = token
+	}
+
+	if url := os.Getenv("SWO_API_URL"); url != "" {
+		config.APIURL = url
+	}
+
+	if config.Token == "" {
+		return nil, errMissingToken
+	}
+
+	if config.APIURL == "" {
+		return nil, errMissingAPIURL
+	}
+
+	return config, nil
+}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,0 +1,95 @@
+package config
+
+import (
+	"errors"
+	"github.com/stretchr/testify/require"
+	"os"
+	"testing"
+)
+
+func createConfigFile(t *testing.T, content string) string {
+	f, err := os.CreateTemp(os.TempDir(), "swo-config-test")
+	require.NoError(t, err, "creating a temporary file should not fail")
+
+	n, err := f.Write([]byte(content))
+	require.Equal(t, n, len(content))
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		os.Remove(f.Name())
+	})
+
+	return f.Name()
+}
+
+func TestLoadConfig(t *testing.T) {
+	testCases := []struct {
+		name          string
+		configFile    string
+		apiURL        string
+		token         string
+		expected      Config
+		expectedError error
+		action        func()
+	}{
+		{
+			name: "read full config file",
+			expected: Config{
+				APIURL: "https://api.solarwinds.com",
+				Token:  "123456",
+			},
+			configFile: func() string {
+				yamlStr := `
+token: 123456
+api-url: https://api.solarwinds.com
+`
+				return createConfigFile(t, yamlStr)
+			}(),
+		},
+		{
+			name: "read token from config file",
+			expected: Config{
+				APIURL: DefaultAPIURL,
+				Token:  "123456",
+			},
+			configFile: func() string {
+				yamlStr := "token: 123456"
+				return createConfigFile(t, yamlStr)
+			}(),
+		},
+		{
+			name: "read token from env var",
+			expected: Config{
+				APIURL: DefaultAPIURL,
+				Token:  "tokenFromEnvVar",
+			},
+			action: func() {
+				err := os.Setenv("SWO_API_TOKEN", "tokenFromEnvVar")
+				require.NoError(t, err)
+			},
+		},
+		{
+			name:          "missing token",
+			expectedError: errMissingToken,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			os.Setenv("SWO_API_TOKEN", "")
+			os.Setenv("SWO_API_URL", "")
+
+			if tc.action != nil {
+				tc.action()
+			}
+
+			cfg, err := Init(tc.configFile, DefaultAPIURL, "")
+			require.True(t, errors.Is(err, tc.expectedError), "error: %v, expected: %v", err, tc.expectedError)
+			if tc.expectedError != nil {
+				return
+			}
+
+			require.Equal(t, &tc.expected, cfg)
+		})
+	}
+}

--- a/logs/client.go
+++ b/logs/client.go
@@ -14,11 +14,6 @@ import (
 	"time"
 )
 
-const (
-	DefaultConfigFile = "~/.swo-cli.yml"
-	DefaultAPIURL     = "https://api.na-01.cloud.solarwinds.com"
-)
-
 var (
 	ErrInvalidAPIResponse = errors.New("Received non-2xx status code")
 	ErrInvalidDateTime    = errors.New("Could not parse timestamp")

--- a/logs/command_get.go
+++ b/logs/command_get.go
@@ -2,30 +2,41 @@ package logs
 
 import (
 	"context"
+	"github.com/solarwinds/swo-cli/config"
 	"github.com/urfave/cli/v2"
 )
 
+const (
+	ConfigContextKey  = "config"
+	GroupContextKey   = "group"
+	SystemContextKey  = "system"
+	MaxTimeContextKey = "max-time"
+	MinTimeContextKey = "min-time"
+	JSONContextKey    = "json"
+	FollowContextKey  = "follow"
+)
+
 var flagsGet = []cli.Flag{
-	&cli.StringFlag{Name: "group", Aliases: []string{"g"}, Usage: "group name to search"},
-	&cli.StringFlag{Name: "min-time", Usage: "earliest time to search from", Value: "1 hour ago"},
-	&cli.StringFlag{Name: "max-time", Usage: "latest time to search from"},
-	&cli.StringFlag{Name: "system", Aliases: []string{"s"}, Usage: "system to search"},
-	&cli.BoolFlag{Name: "json", Aliases: []string{"j"}, Usage: "output raw JSON", Value: false},
-	&cli.BoolFlag{Name: "follow", Aliases: []string{"f"}, Usage: "enable live tailing", Value: false},
+	&cli.StringFlag{Name: GroupContextKey, Aliases: []string{"g"}, Usage: "group name to search"},
+	&cli.StringFlag{Name: MinTimeContextKey, Usage: "earliest time to search from", Value: "1 hour ago"},
+	&cli.StringFlag{Name: MaxTimeContextKey, Usage: "latest time to search from"},
+	&cli.StringFlag{Name: SystemContextKey, Aliases: []string{"s"}, Usage: "system to search"},
+	&cli.BoolFlag{Name: JSONContextKey, Aliases: []string{"j"}, Usage: "output raw JSON", Value: false},
+	&cli.BoolFlag{Name: FollowContextKey, Aliases: []string{"f"}, Usage: "enable live tailing", Value: false},
 }
 
 func runGet(cCtx *cli.Context) error {
 	opts := &Options{
 		args:       cCtx.Args().Slice(),
-		configFile: cCtx.String("config"),
-		group:      cCtx.String("group"),
-		system:     cCtx.String("system"),
-		maxTime:    cCtx.String("max-time"),
-		minTime:    cCtx.String("min-time"),
-		json:       cCtx.Bool("json"),
-		follow:     cCtx.Bool("follow"),
-		APIURL:     cCtx.String("api-url"),
-		Token:      cCtx.String("api-token"),
+		configFile: cCtx.String(ConfigContextKey),
+		group:      cCtx.String(GroupContextKey),
+		system:     cCtx.String(SystemContextKey),
+		maxTime:    cCtx.String(MaxTimeContextKey),
+		minTime:    cCtx.String(MinTimeContextKey),
+		json:       cCtx.Bool(JSONContextKey),
+		follow:     cCtx.Bool(FollowContextKey),
+		APIURL:     cCtx.String(config.APIURLContextKey),
+		Token:      cCtx.String(config.TokenContextKey),
 	}
 	if err := opts.Init(cCtx.Args().Slice()); err != nil {
 		return err

--- a/logs/options.go
+++ b/logs/options.go
@@ -2,23 +2,17 @@ package logs
 
 import (
 	"errors"
-	"fmt"
-	"os"
-	"os/user"
-	"path/filepath"
 	"strings"
 	"time"
 
 	"github.com/olebedev/when"
-	"gopkg.in/yaml.v3"
 )
 
 var (
 	now = time.Now()
 
-	errMinTimeFlag  = errors.New("failed to parse --min-time flag")
-	errMaxTimeFlag  = errors.New("failed to parse --max-time flag")
-	errMissingToken = errors.New("failed to find token")
+	errMinTimeFlag = errors.New("failed to parse --min-time flag")
+	errMaxTimeFlag = errors.New("failed to parse --max-time flag")
 
 	timeLayouts = []string{
 		time.Layout,
@@ -52,9 +46,8 @@ type Options struct {
 	minTime    string
 	json       bool
 	follow     bool
-
-	APIURL string `yaml:"api-url"`
-	Token  string `yaml:"token"`
+	Token      string
+	APIURL     string
 }
 
 func (opts *Options) Init(args []string) error {
@@ -85,39 +78,6 @@ func (opts *Options) Init(args []string) error {
 		}
 
 		opts.maxTime = result
-	}
-
-	configPath := opts.configFile
-	cwd, err := os.Getwd()
-	if err != nil {
-		return err
-	}
-
-	localConfig := filepath.Join(cwd, ".swo-cli.yaml")
-	if _, err := os.Stat(localConfig); err == nil {
-		configPath = localConfig
-	} else if strings.HasPrefix(opts.configFile, "~/") {
-		usr, err := user.Current()
-		if err != nil {
-			return fmt.Errorf("error while resolving current user to read configuration file: %w", err)
-		}
-
-		configPath = filepath.Join(usr.HomeDir, opts.configFile[2:])
-	}
-
-	if content, err := os.ReadFile(configPath); err == nil {
-		err = yaml.Unmarshal(content, opts)
-		if err != nil {
-			return fmt.Errorf("error while unmarshaling %s config file: %w", configPath, err)
-		}
-	}
-
-	if token := os.Getenv("SWO_API_TOKEN"); token != "" {
-		opts.Token = token
-	}
-
-	if opts.Token == "" {
-		return errMissingToken
 	}
 
 	return nil

--- a/logs/options_test.go
+++ b/logs/options_test.go
@@ -26,85 +26,24 @@ func TestNewOptions(t *testing.T) {
 		expectedError error
 	}{
 		{
-			name: "read full config file",
-			opts: &Options{configFile: configFile},
-			expected: Options{
-				args:       []string{},
-				configFile: configFile,
-				APIURL:     "https://api.solarwinds.com",
-				Token:      "123456",
-			},
-			action: func() {
-				yamlStr := `
-token: 123456
-api-url: https://api.solarwinds.com
-`
-				createConfigFile(t, configFile, yamlStr)
-			},
-		},
-		{
-			name: "read token from config file",
-			opts: &Options{configFile: configFile, APIURL: DefaultAPIURL},
-			expected: Options{
-				args:       []string{},
-				configFile: configFile,
-				APIURL:     DefaultAPIURL,
-				Token:      "123456",
-			},
-			action: func() {
-				yamlStr := "token: 123456"
-				createConfigFile(t, configFile, yamlStr)
-			},
-		},
-		{
-			name: "read token from env var",
-			opts: &Options{configFile: DefaultConfigFile, APIURL: DefaultAPIURL},
-			expected: Options{
-				args:       []string{},
-				configFile: DefaultConfigFile,
-				APIURL:     DefaultAPIURL,
-				Token:      "tokenFromEnvVar",
-			},
-			action: func() {
-				err := os.Setenv("SWO_API_TOKEN", "tokenFromEnvVar")
-				require.NoError(t, err)
-			},
-		},
-		{
-			name: "missing token",
-			opts: &Options{},
-			expected: Options{
-				args: []string{},
-			},
-			expectedError: errMissingToken,
-		},
-		{
 			name: "parse human readable min time",
-			opts: &Options{configFile: configFile, minTime: "5 seconds ago"},
+			opts: &Options{minTime: "5 seconds ago"},
 			expected: Options{
-				args:       []string{},
-				configFile: configFile,
-				minTime:    "2000-01-01T10:00:25Z",
-				Token:      "123456",
+				args:    []string{},
+				minTime: "2000-01-01T10:00:25Z",
 			},
 			action: func() {
-				yamlStr := "token: 123456"
-				createConfigFile(t, configFile, yamlStr)
 				now = fixedTime
 			},
 		},
 		{
 			name: "parse human readable max time",
-			opts: &Options{configFile: configFile, maxTime: "in 5 seconds"},
+			opts: &Options{maxTime: "in 5 seconds"},
 			expected: Options{
-				args:       []string{},
-				configFile: configFile,
-				maxTime:    "2000-01-01T10:00:35Z",
-				Token:      "123456",
+				args:    []string{},
+				maxTime: "2000-01-01T10:00:35Z",
 			},
 			action: func() {
-				yamlStr := "token: 123456"
-				createConfigFile(t, configFile, yamlStr)
 				now = fixedTime
 			},
 		},


### PR DESCRIPTION
Rather than having config file parsing be part of the logs package, let's move it out so that it can easily be shared between additional commands as they arise.