### PR TITLE
chore: Migrate Windows signing from SignPath to Azure Trusted Signing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v8
         with:
-          version: v2.2.1
+          version: v2.11.4
   build:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v8
         with:
-          version: v2.11.4
+          version: v2.2.1
   build:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,7 @@ jobs:
         with:
           go-version: 1.22
       - name: Checkout solarwinds-actions/gha-signing
+        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
         uses: actions/checkout@v4
         with:
           repository: solarwinds-actions/gha-signing
@@ -45,13 +46,15 @@ jobs:
           SWO_MAC_P8_FILE: ${{ secrets.SWO_MAC_P8_FILE }}
           SWO_MAC_P12_CERT: ${{ secrets.SWO_MAC_P12_CERT }}
           SWO_P12_PASSWORD: ${{ secrets.SWO_P12_PASSWORD }}
-      - name: Azure Login
+      - name: Azure Login (Federated Identity)
+        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
         uses: azure/login@v2
         with:
           client-id: ${{ vars.AZURE_CLIENT_ID }}
           tenant-id: ${{ vars.AZURE_TENANT_ID }}
           subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
-      - name: Sign Windows binary
+      - name: Sign Files
+        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
         uses: ./.github/actions/gha-signing/ats-sign
         with:
           files-to-sign: "*.exe,*.dll"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: write
+  id-token: write
   # packages: write
   # issues: write
 
@@ -24,21 +25,45 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: 1.22
-      - name: Install SignPath Powershell module
-        shell: pwsh
-        run: Install-Module -Name SignPath -Confirm:$False -Force
+      - name: Checkout solarwinds-actions/gha-signing
+        uses: actions/checkout@v4
+        with:
+          repository: solarwinds-actions/gha-signing
+          token: ${{ secrets.FGPAT_ENOPS_7950_SOLARWINDS_ACTIONS }}
+          ref: v1
+          path: ./.github/actions/gha-signing
+      - name: Build binaries
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: "~> v1"
+          args: build --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SWO_ISSUER_ID: ${{ secrets.SWO_ISSUER_ID }}
+          SWO_KEY_ID: ${{ secrets.SWO_KEY_ID }}
+          SWO_MAC_P8_FILE: ${{ secrets.SWO_MAC_P8_FILE }}
+          SWO_MAC_P12_CERT: ${{ secrets.SWO_MAC_P12_CERT }}
+          SWO_P12_PASSWORD: ${{ secrets.SWO_P12_PASSWORD }}
+      - name: Azure Login
+        uses: azure/login@v2
+        with:
+          client-id: ${{ vars.AZURE_CLIENT_ID }}
+          tenant-id: ${{ vars.AZURE_TENANT_ID }}
+          subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+      - name: Sign Windows binary
+        uses: ./.github/actions/gha-signing/ats-sign
+        with:
+          files-to-sign: "*.exe,*.dll"
+          cert-profile: ${{ vars.ATS_CERT_PROFILE }}
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:
           distribution: goreleaser
           version: "~> v1"
-          args: release --clean
+          args: release --skip-build
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SP_CI_USER_TOKEN: ${{ secrets.SP_CI_USER_TOKEN }}
-          SP_ORGANIZATION_ID: ${{ secrets.SP_ORGANIZATION_ID }}
-          SP_PROJECT: ${{ secrets.SP_PROJECT }}
-
           SWO_ISSUER_ID: ${{ secrets.SWO_ISSUER_ID }}
           SWO_KEY_ID: ${{ secrets.SWO_KEY_ID }}
           SWO_MAC_P8_FILE: ${{ secrets.SWO_MAC_P8_FILE }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,19 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: 1.22
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: "~> v1"
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SWO_ISSUER_ID: ${{ secrets.SWO_ISSUER_ID }}
+          SWO_KEY_ID: ${{ secrets.SWO_KEY_ID }}
+          SWO_MAC_P8_FILE: ${{ secrets.SWO_MAC_P8_FILE }}
+          SWO_MAC_P12_CERT: ${{ secrets.SWO_MAC_P12_CERT }}
+          SWO_P12_PASSWORD: ${{ secrets.SWO_P12_PASSWORD }}
       - name: Checkout solarwinds-actions/gha-signing
         if: ${{ startsWith(github.ref, 'refs/tags/v') }}
         uses: actions/checkout@v4
@@ -33,19 +46,6 @@ jobs:
           token: ${{ secrets.FGPAT_ENOPS_7950_SOLARWINDS_ACTIONS }}
           ref: v1
           path: ./.github/actions/gha-signing
-      - name: Build binaries
-        uses: goreleaser/goreleaser-action@v6
-        with:
-          distribution: goreleaser
-          version: "~> v1"
-          args: build --clean
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SWO_ISSUER_ID: ${{ secrets.SWO_ISSUER_ID }}
-          SWO_KEY_ID: ${{ secrets.SWO_KEY_ID }}
-          SWO_MAC_P8_FILE: ${{ secrets.SWO_MAC_P8_FILE }}
-          SWO_MAC_P12_CERT: ${{ secrets.SWO_MAC_P12_CERT }}
-          SWO_P12_PASSWORD: ${{ secrets.SWO_P12_PASSWORD }}
       - name: Azure Login (Federated Identity)
         if: ${{ startsWith(github.ref, 'refs/tags/v') }}
         uses: azure/login@v2
@@ -59,16 +59,3 @@ jobs:
         with:
           files-to-sign: "*.exe,*.dll"
           cert-profile: ${{ vars.ATS_CERT_PROFILE }}
-      - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v6
-        with:
-          distribution: goreleaser
-          version: "~> v1"
-          args: release --skip-build
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SWO_ISSUER_ID: ${{ secrets.SWO_ISSUER_ID }}
-          SWO_KEY_ID: ${{ secrets.SWO_KEY_ID }}
-          SWO_MAC_P8_FILE: ${{ secrets.SWO_MAC_P8_FILE }}
-          SWO_MAC_P12_CERT: ${{ secrets.SWO_MAC_P12_CERT }}
-          SWO_P12_PASSWORD: ${{ secrets.SWO_P12_PASSWORD }}

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -11,8 +11,3 @@ linters:
     - nilnil
     - nilerr
     - staticcheck
-  exclusions:
-    rules:
-      - path: _test\.go
-        linters:
-          - gosec

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,9 +12,8 @@ linters:
     - nilerr
     - staticcheck
 
-issues:
-  exclusions:
-    rules:
-      - path: _test\.go
-        linters:
-          - gosec
+exclusions:
+  rules:
+    - path: _test\.go
+      linters:
+        - gosec

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -11,3 +11,8 @@ linters:
     - nilnil
     - nilerr
     - staticcheck
+  exclusions:
+    rules:
+      - path: _test\.go
+        linters:
+          - gosec

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -16,3 +16,4 @@ linters:
       - path: _test\.go
         linters:
           - gosec
+        text: "G101"

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -11,3 +11,10 @@ linters:
     - nilnil
     - nilerr
     - staticcheck
+
+issues:
+  exclusions:
+    rules:
+      - path: _test\.go
+        linters:
+          - gosec

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -11,9 +11,8 @@ linters:
     - nilnil
     - nilerr
     - staticcheck
-
-exclusions:
-  rules:
-    - path: _test\.go
-      linters:
-        - gosec
+  exclusions:
+    rules:
+      - path: _test\.go
+        linters:
+          - gosec

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -21,13 +21,6 @@ builds:
       - "-s -w -X 'main.version=v{{ .Version }}'"
     targets:
       - windows_amd64
-    hooks:
-      post:
-        - env:
-            - SP_SIGNING_POLICY=Release
-            - SP_ARTIFACT_CONFIGURATION=exe
-          cmd: pwsh -c "Submit-SigningRequest -ApiToken "$env:SP_CI_USER_TOKEN" -OrganizationId "$env:SP_ORGANIZATION_ID" -ProjectSlug "$env:SP_PROJECT" -SigningPolicySlug "$env:SP_SIGNING_POLICY" -ArtifactConfigurationSlug "$env:SP_ARTIFACT_CONFIGURATION" -InputArtifactPath '{{ .Path }}' -OutputArtifactPath '{{ .Path }}' -Force -WaitForCompletion"
-          output: true
 
 archives:
   - builds:

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -152,7 +152,7 @@ api-url: https://config.example.com
 			}(),
 		},
 		{
-			name:     "read token from env var",
+			name: "read token from env var",
 			expected: Config{
 				APIURL: DefaultAPIURL,
 				Token:  "tokenFromEnvVar",

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -153,7 +153,7 @@ api-url: https://config.example.com
 		},
 		{
 			name:     "read token from env var",
-			expected: Config{ //nolint:gosec
+			expected: Config{
 				APIURL: DefaultAPIURL,
 				Token:  "tokenFromEnvVar",
 			},
@@ -213,7 +213,7 @@ func TestTrimmingWhitespace(t *testing.T) {
 		expected   Config
 		action     func()
 	}{
-		{ //nolint:gosec
+		{
 			name:   "trim CLI arguments",
 			apiURL: "  https://cli.example.com  ",
 			token:  "  cli_token  ",
@@ -299,7 +299,7 @@ api-url: "   "
 				return createConfigFile(t, yamlStr)
 			}(),
 		},
-		{ //nolint:gosec
+		{
 			name:  "mixed whitespace scenarios",
 			token: "  cli_token  ", // CLI token with whitespace
 			expected: Config{

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -152,8 +152,8 @@ api-url: https://config.example.com
 			}(),
 		},
 		{
-			name: "read token from env var",
-			expected: Config{
+			name:     "read token from env var",
+			expected: Config{ //nolint:gosec
 				APIURL: DefaultAPIURL,
 				Token:  "tokenFromEnvVar",
 			},
@@ -213,7 +213,7 @@ func TestTrimmingWhitespace(t *testing.T) {
 		expected   Config
 		action     func()
 	}{
-		{
+		{ //nolint:gosec
 			name:   "trim CLI arguments",
 			apiURL: "  https://cli.example.com  ",
 			token:  "  cli_token  ",
@@ -299,7 +299,7 @@ api-url: "   "
 				return createConfigFile(t, yamlStr)
 			}(),
 		},
-		{
+		{ //nolint:gosec
 			name:  "mixed whitespace scenarios",
 			token: "  cli_token  ", // CLI token with whitespace
 			expected: Config{

--- a/entities/client.go
+++ b/entities/client.go
@@ -197,9 +197,9 @@ func (c *Client) prepareListTypesRequest(ctx context.Context) (*http.Request, er
 }
 
 func (c *Client) doRequest(req *http.Request) ([]byte, error) {
-	slog.Debug("Sending HTTP request", "method", req.Method, "url", req.URL.String()) //nolint:gosec
+	slog.Debug("Sending HTTP request", "method", req.Method, "url", req.URL.String())
 
-	response, err := c.httpClient.Do(req) //nolint:gosec
+	response, err := c.httpClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("error while sending http request to SWO: %w", err)
 	}

--- a/entities/client.go
+++ b/entities/client.go
@@ -197,9 +197,9 @@ func (c *Client) prepareListTypesRequest(ctx context.Context) (*http.Request, er
 }
 
 func (c *Client) doRequest(req *http.Request) ([]byte, error) {
-	slog.Debug("Sending HTTP request", "method", req.Method, "url", req.URL.String())
+	slog.Debug("Sending HTTP request", "method", req.Method, "url", req.URL.String()) //nolint:gosec
 
-	response, err := c.httpClient.Do(req)
+	response, err := c.httpClient.Do(req) //nolint:gosec
 	if err != nil {
 		return nil, fmt.Errorf("error while sending http request to SWO: %w", err)
 	}


### PR DESCRIPTION
Migrates Windows binary signing from SignPath to Azure Trusted Signing (ATS).

- Removes SignPath goreleaser post-build hook and secrets (`SP_CI_USER_TOKEN`, `SP_ORGANIZATION_ID`, `SP_PROJECT`)
- Removes SignPath PowerShell module install step
- Adds `id-token: write` for Azure OIDC
- Adds the three ATS steps after goreleaser completes: checkout `gha-signing` → Azure Login (OIDC) → Sign Files (`*.exe,*.dll`)

All required secrets/vars are configured in the `prod` environment.