### PR TITLE
chore: bump version to v1.3.7

### DIFF
--- a/cmd/swo/main.go
+++ b/cmd/swo/main.go
@@ -13,7 +13,7 @@ import (
 )
 
 // Automatically updated by goreleaser in CI
-var version = "v1.3.3"
+var version = "v1.3.7"
 
 func main() {
 	app := &cli.App{


### PR DESCRIPTION
Bumps version string in `cmd/swo/main.go` to v1.3.7 in preparation for the next release.